### PR TITLE
Downgrade node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM node:8.17-alpine
 MAINTAINER Slavey Karadzhov "slav@attachix.com"
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
I suggest to downgrade node version to 8. Otherwise terminal in cloud9 doesn't work (some problem with installing pty.js)